### PR TITLE
Update BTime.h

### DIFF
--- a/PacketProcessor/tun2socks-iOS/system/BTime.h
+++ b/PacketProcessor/tun2socks-iOS/system/BTime.h
@@ -135,7 +135,7 @@ static btime_t btime_gettime (void)
         return ((int64_t)tv.tv_sec * 1000 + (int64_t)tv.tv_usec/1000);
     } else {
         struct timespec ts;
-        ASSERT_FORCE(clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+        ASSERT_FORCE(clock_gettime_ex(CLOCK_MONOTONIC, &ts) == 0)
         return (((int64_t)ts.tv_sec * 1000 + (int64_t)ts.tv_nsec/1000000) - btime_global.start_time);
     }
     


### PR DESCRIPTION
Fix iOS 9 clock_gettime issue.

I think you miss on function in BTime.c, so tha Tunnel Process will crash on iOS 9.

I test it on iPhone7(iOS 10.3.1) and iPad 3(iOS 9.0.2), and it works.