### PR TITLE
Fix the memory leak In recent request link list.

### DIFF
--- a/Library/ShadowPath/ShadowPath/Privoxy/jcc.m
+++ b/Library/ShadowPath/ShadowPath/Privoxy/jcc.m
@@ -3371,7 +3371,9 @@ static void add_log_csp(struct client_state *csp) {
         log_clients->csp->flags &= ~CSP_FLAG_LOG_REQUEST;
         struct log_client_states *tmp = log_clients;
         log_clients = log_clients->next;
-        free(tmp);
+        tmp->csp = NULL;
+        tmp->next = NULL;
+        freez(tmp);
         log_clients_count --;
     }
     unlock_log_request();

--- a/Library/ShadowPath/ShadowPath/Privoxy/jcc.m
+++ b/Library/ShadowPath/ShadowPath/Privoxy/jcc.m
@@ -3369,7 +3369,9 @@ static void add_log_csp(struct client_state *csp) {
 
     if (log_clients_count > max_log_clients_count) {
         log_clients->csp->flags &= ~CSP_FLAG_LOG_REQUEST;
+        struct log_client_states *tmp = log_clients;
         log_clients = log_clients->next;
+        free(tmp);
         log_clients_count --;
     }
     unlock_log_request();


### PR DESCRIPTION
The add_log_csp() function is used to record recent request. The function store the request with a C++ style link chain.
When the requests in the link chain get to the max_log_clients_count, function will remove the first link from the link chain, and here is the problem.
The removal of the link action just change the pointer of the first link, so the memory of the old first link will be no reference anymore. The memory leak happens.
With Instruments, you will find the leak track the memory on zalloc() in this function.
What I do is just create a temporary reference for the first link that should be remove from the link chain, and free the memory after the old first link is removed.
Without this memory leak, the thread should be running in a better situation.