### PR TITLE
Fix validating port number

### DIFF
--- a/Potatso/Advance/ProxyConfigurationViewController.swift
+++ b/Potatso/Advance/ProxyConfigurationViewController.swift
@@ -188,7 +188,7 @@ class ProxyConfigurationViewController: FormViewController {
             guard let port = values[kProxyFormPort] as? Int else {
                 throw "Port can't be empty".localized()
             }
-            guard port > 0 && port < Int(UINT16_MAX) else {
+            guard port > 0 && port <= Int(UINT16_MAX) else {
                 throw "Invalid port".localized()
             }
             var authscheme: String?


### PR DESCRIPTION
The issue was spotted on Potatso Lite on App Store, and I have not yet test the change.